### PR TITLE
cbEnchanted kääntymään Arch64:ssä

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ docs
 # Temporary files
 *~
 *.kate-swp
+*.swp
 
 # Dolphin (KDE File Manager) created files
 .directory

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,9 @@ list(APPEND LIBS "allegro_dialog")
 
 list(APPEND LIBS "png")
 list(APPEND LIBS "openal")
+if(UNIX)
+	list(APPEND LIBS "dl")
+endif()
 
 find_package(OpenGL REQUIRED)
 include_directories(${OPENGL_INCLUDE_DIR})

--- a/src/cbenchanted.cpp
+++ b/src/cbenchanted.cpp
@@ -343,9 +343,10 @@ void CBEnchanted::parseCustomFunction(uint32_t i, map<int32_t, int32_t> &tempMap
 	}
 	i2 += 4;
 	//commandFunction
-	int32_t paramCount = 0;
+	int32_t paramCount;
 	int32_t opc;
 	int32_t comc;
+	paramCount = 0; //See line 385
 	while ((opc = code[i2]) == 67 && (comc = *(int32_t*)(code + i2 + 1)) == 79) {
 		i2 += 6;
 		paramCount++;
@@ -380,7 +381,8 @@ void CBEnchanted::parseCustomFunction(uint32_t i, map<int32_t, int32_t> &tempMap
 	if (code[i2++] != 73) { //PushInt
 		goto not_custom_function;
 	}
-	int pushValue = *(int32_t*)(code + i2);
+	int pushValue;
+	pushValue = *(int32_t*)(code + i2); //Not running constructor fixes cross initialization
 	if (pushValue != 0) { //Return == 0
 		if (pushValue != 2 && pushValue != 5) { //handlePushSomething() IDs of float(2) and string(5)
 			goto not_custom_function;


### PR DESCRIPTION
Systeeminä siis Arch64  / GCC 4.7.0 / libstdc++ 3.4.17 / libc 2.15
Edellinen versio herjasi cross initializationia ja dlsymin puuttumista.

Muutokset:
Linking libdl on UNIX systems in CMakeLists.txt
Two variable initialisations in cbenchanted.cpp changed to
not run initialisers to prevent "crosses initialization"
error with GCC 4.7.0
