### PR TITLE
Use right value for tileCount in CBMap::create because we don't...

### DIFF
--- a/src/cbmap.cpp
+++ b/src/cbmap.cpp
@@ -40,7 +40,7 @@ bool CBMap::create(uint32_t width, uint32_t height, uint16_t tileW, uint16_t til
 		layers[i] = new int32_t[width * height];
 		memset(layers[i], 0, width * height * sizeof(int32_t));
 	}
-	tileCount = 64; //Default size. Arrays will be resized if more tiles are used.
+	tileCount = width * height;
 	currentFrame = new float [tileCount];
 	animSlowness = new int32_t [tileCount];
 	animLength = new int32_t [tileCount];


### PR DESCRIPTION
…change it ever outside MakeMap, LoadMap or SetTile.
Possibly related issue: https://github.com/cb-hackers/cbEnchanted/issues/161